### PR TITLE
Update parseInt.js

### DIFF
--- a/parseInt.js
+++ b/parseInt.js
@@ -32,6 +32,7 @@
             var result = orig.apply(this, arguments);
             if(!isNaN(result)) return result;   ///< 如果是舊函數已支援的情形，那就回傳舊函數的結果
             if(!arguments.length) return chars; ///< 互動用。把對照表取回，可用於另做支援比對的RegExp
+            if(undefined === arguments[0]) return NaN; ///< mimic original parseInt()
 
             var str = arguments[0].toString().replace(/[\s　]/g, "");
             var negative = /^[負负-]/.test(str);


### PR DESCRIPTION
mimic original parseInt() when arguments[0] is undefined.

對了，當得跟別的 lib 一起用時，不覺得更改 parseInt() 的行為是個好主意。
